### PR TITLE
8.8.3: Migrate validation builders to service-builder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -856,7 +856,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
- "service-builder",
+ "service-builder 0.2.2",
  "thiserror 1.0.69",
  "tokio",
  "tracing",
@@ -874,7 +874,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
- "service-builder",
+ "service-builder 0.2.2",
  "thiserror 1.0.69",
  "tokio",
  "tracing",
@@ -892,7 +892,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
- "service-builder",
+ "service-builder 0.2.2",
  "thiserror 1.0.69",
  "tokio",
  "tracing",
@@ -1111,6 +1111,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
+ "service-builder 0.3.0",
  "thiserror 1.0.69",
  "tokio",
  "tokio-test",
@@ -2987,7 +2988,21 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "service-builder-macro",
+ "service-builder-macro 0.2.2",
+ "syn 2.0.104",
+ "thiserror 2.0.14",
+]
+
+[[package]]
+name = "service-builder"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7b843738e1df174d5eb42765be172b8a5b4b0c92fd04edace8c090d31228387"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "service-builder-macro 0.3.0",
  "syn 2.0.104",
  "thiserror 2.0.14",
 ]
@@ -2997,6 +3012,19 @@ name = "service-builder-macro"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6b19d3ecbb23bfbf0fb60dd3ef624a8538597174da4a5ce790c63f108e08c68"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+ "thiserror 2.0.14",
+]
+
+[[package]]
+name = "service-builder-macro"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57a0a69401082d3f769cbc5e36f3c6555cb407fd86263af004fbefef6510eb48"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/crates/elif-validation/Cargo.toml
+++ b/crates/elif-validation/Cargo.toml
@@ -19,6 +19,7 @@ regex = { workspace = true }
 chrono = { workspace = true }
 uuid = { workspace = true }
 thiserror = { workspace = true }
+service-builder = "0.3.0"
 
 [dev-dependencies]
 tokio = { workspace = true }


### PR DESCRIPTION
## Summary
- Migrated validation builders to use service-builder 0.3.0 `#[builder]` macro
- Replaced manual RulesBuilder implementation with generated builder pattern
- Maintained all existing high-level validation methods and fluent API

## Changes Made
- Added service-builder 0.3.0 dependency to elif-validation
- Created RulesBuilderConfig struct with `#[builder]` macro
- Added convenience methods to generated builder for dynamic rule addition
- Maintained backward compatibility with existing validation methods:
  - `required_string()`, `required_email()`, `optional_email()`
  - `required_number()`, `required_integer()`
  - `pattern()`, `one_of()`, `custom()`, `request_rule()`

## Technical Implementation
- Uses wrapper pattern: RulesBuilder delegates to RulesBuilderConfigBuilder
- RulesBuilderConfig contains HashMap for field rules and Vec for request rules
- Manual Debug implementation to handle non-Debug ValidationRule trait
- All convenience methods updated to use generated builder methods

## Test Results
- All 80 validation tests pass
- Maintains existing validation functionality
- Preserves fluent API for rule composition

## Files Modified
- `crates/elif-validation/Cargo.toml` - Added service-builder dependency
- `crates/elif-validation/src/rules.rs` - Migrated to service-builder pattern

🤖 Generated with [Claude Code](https://claude.ai/code)