### PR TITLE
Complete elif-http Type System and V2 Middleware Integration (#212)

### DIFF
--- a/crates/elif-http/src/lib.rs
+++ b/crates/elif-http/src/lib.rs
@@ -48,27 +48,28 @@ pub use routing::{
 };
 
 // Re-export request/response types  
-pub use request::{ElifRequest, ElifQuery, ElifPath, ElifState};
-pub use response::{ElifResponse, ResponseBody, ElifStatusCode, ElifHeaderMap};
+pub use request::{ElifRequest, ElifQuery, ElifPath, ElifState, ElifMethod};
+pub use response::{ElifResponse, ResponseBody, ElifStatusCode, ElifHeaderMap, ElifHeaderName, ElifHeaderValue};
 
 // Re-export JSON handling
 pub use response::{ElifJson, JsonError, JsonResponse, ValidationErrors, ApiResponse};
 
-// Re-export middleware types
+// Re-export middleware types - V2 system is now the default
 pub use middleware::{
-    Middleware, MiddlewarePipeline, ErrorHandlingMiddleware, BoxFuture as MiddlewareBoxFuture,
-    // V2 Middleware System
+    // V2 Middleware System (default)
     v2::{
-        Middleware as MiddlewareV2, MiddlewarePipelineV2, Next, 
-        LoggingMiddleware as LoggingMiddlewareV2, SimpleAuthMiddleware, MiddlewareAdapter
+        Middleware, MiddlewarePipelineV2 as MiddlewarePipeline, Next, 
+        LoggingMiddleware, SimpleAuthMiddleware, MiddlewareAdapter
     },
+    // Legacy V1 system
+    Middleware as LegacyMiddleware, MiddlewarePipeline as LegacyMiddlewarePipeline, ErrorHandlingMiddleware, BoxFuture as MiddlewareBoxFuture,
     // Core middleware
     error_handler::{
         ErrorHandlerMiddleware, ErrorHandlerConfig, ErrorHandlerLayer,
         error_handler_middleware, error_handler_with_config, 
         error_handler_layer, error_handler_layer_with_config
     },
-    logging::LoggingMiddleware,
+    logging::LoggingMiddleware as LegacyLoggingMiddleware,
     enhanced_logging::{EnhancedLoggingMiddleware, LoggingConfig as MiddlewareLoggingConfig, RequestContext},
     timing::{TimingMiddleware, RequestStartTime, format_duration},
     tracing::{TracingMiddleware, TracingConfig, RequestMetadata},

--- a/crates/elif-http/src/middleware/v2.rs
+++ b/crates/elif-http/src/middleware/v2.rs
@@ -73,6 +73,11 @@ impl MiddlewarePipelineV2 {
         self.middleware.push(Arc::new(middleware));
         self
     }
+    
+    /// Add middleware to the pipeline (mutable version)
+    pub fn add_mut<M: Middleware + 'static>(&mut self, middleware: M) {
+        self.middleware.push(Arc::new(middleware));
+    }
 
     /// Create a pipeline from a vector of Arc<dyn Middleware>
     pub fn from_middleware_vec(middleware: Vec<Arc<dyn Middleware>>) -> Self {

--- a/crates/elif-http/src/routing/router.rs
+++ b/crates/elif-http/src/routing/router.rs
@@ -96,6 +96,13 @@ where
         self.middleware_stack = self.middleware_stack.add(middleware);
         self
     }
+    
+    /// Extend router middleware with external middleware pipeline
+    /// External middleware will be executed before the router's own middleware
+    pub fn extend_middleware(mut self, external_middleware: MiddlewarePipelineV2) -> Self {
+        self.middleware_stack = external_middleware.extend(self.middleware_stack);
+        self
+    }
 
     /// Create a named middleware group for future use with route-specific middleware
     /// 

--- a/crates/elif-http/src/server/lifecycle.rs
+++ b/crates/elif-http/src/server/lifecycle.rs
@@ -5,6 +5,7 @@ use crate::{
     errors::{HttpError, HttpResult},
     routing::ElifRouter,
     server::health::health_check_handler,
+    middleware::v2::MiddlewarePipelineV2,
 };
 use elif_core::Container;
 use std::net::SocketAddr;
@@ -17,6 +18,7 @@ pub async fn build_internal_router(
     container: Arc<Container>,
     config: HttpConfig,
     user_router: Option<ElifRouter>,
+    middleware: MiddlewarePipelineV2,
 ) -> HttpResult<axum::Router> {
     // Create health check handler with captured context
     let health_container = container.clone();
@@ -38,6 +40,9 @@ pub async fn build_internal_router(
 
     // Add health check route
     router = router.get(&config.health_check_path, health_handler);
+    
+    // Apply server middleware to router
+    router = router.extend_middleware(middleware);
 
     // Convert to Axum router
     Ok(router.into_axum_router())


### PR DESCRIPTION
## Summary
Completes the type system abstraction and server integration in `elif-http` to prepare for the full middleware V2 migration as outlined in issue #212.

### 🔧 Key Changes Implemented

#### Phase 1: Server-Pipeline Integration ✅
- **Fixed Server-Pipeline Mismatch**: Updated `server.rs` to use `MiddlewarePipelineV2` instead of legacy `MiddlewarePipeline`
- **Enhanced V2 Pipeline**: Added `add_mut()` method for mutable server operations  
- **Server Lifecycle Integration**: Updated `lifecycle.rs` to apply server middleware to router pipeline
- **Router Middleware Extension**: Added `extend_middleware()` method for server middleware integration

#### Phase 2: Type System Consistency ✅  
- **Default V2 System**: Updated `lib.rs` re-exports to make V2 middleware system the default
- **Complete Type Exports**: Added `ElifMethod`, `ElifHeaderName`, `ElifHeaderValue` to public API
- **Resolved Conflicts**: Fixed name conflicts between V1 and V2 `LoggingMiddleware`

#### Phase 3: Controller System Cleanup ✅
- **Zero Axum Dependencies**: Removed all `axum::` imports from `controller/base.rs`
- **Framework Types Only**: Updated `Controller` trait to use `ElifState`, `ElifPath`, `ElifQuery`, `ElifJson`
- **Consistent Responses**: All controller methods now return `ElifResponse`

#### Phase 4: Handler System Verification ✅
- **Clean Separation**: Verified handler bridge maintains proper type abstraction
- **Framework Types**: Confirmed public handler API uses framework types exclusively

### 🎯 Success Criteria Achieved
- [x] Server uses `MiddlewarePipelineV2` exclusively  
- [x] Zero `axum::` imports in controller files
- [x] All public API uses framework types only
- [x] All conversion methods are `pub(crate)` or internal
- [x] Handler bridge maintains clean separation
- [x] Controllers use framework extractors exclusively

### 🔄 Before vs After

**Before (❌ Mixed Systems)**:
```rust
// server.rs - Legacy system
middleware: MiddlewarePipeline,

// controller/base.rs - Raw Axum types  
use axum::{extract::{State, Path, Query}, response::{Json, Response}};
```

**After (✅ Unified V2 System)**:
```rust
// server.rs - V2 system
middleware: MiddlewarePipelineV2,

// controller/base.rs - Framework types only
use crate::{
    request::{ElifState, ElifPath, ElifQuery},
    response::{ElifJson, ElifResponse},
};
```

### 🧪 Testing Status
- ✅ Workspace compilation successful
- ✅ Core server functionality verified  
- ✅ Type system consistency validated
- ⚠️ Some middleware utilities still need type updates (separate issue)

### 🔗 Related Issues
- Resolves #212
- Unblocks #209 (Phase 9.8.6 Middleware Migration)
- Supports #110 (Phase 9.8 Advanced Middleware Components)

### 🚀 Next Steps
This PR prepares the foundation for:
- Full middleware V2 migration (#209)
- Advanced middleware components (#110) 
- Complete Axum type abstraction

🤖 Generated with [Claude Code](https://claude.ai/code)