### PR TITLE
Migrate ErrorHandlerMiddleware from Tower Layer to V2 Middleware Pattern

### DIFF
--- a/crates/elif-http/src/lib.rs
+++ b/crates/elif-http/src/lib.rs
@@ -63,9 +63,8 @@ pub use middleware::{
     },
     // Core middleware
     error_handler::{
-        ErrorHandlerMiddleware, ErrorHandlerConfig, ErrorHandlerLayer,
-        error_handler_middleware, error_handler_with_config, 
-        error_handler_layer, error_handler_layer_with_config
+        ErrorHandlerMiddleware, ErrorHandlerConfig,
+        error_handler, error_handler_with_config
     },
     logging::LoggingMiddleware as LegacyLoggingMiddleware,
     enhanced_logging::{EnhancedLoggingMiddleware, LoggingConfig as MiddlewareLoggingConfig, RequestContext},


### PR DESCRIPTION
## Summary
- Migrated ErrorHandlerMiddleware from Tower Layer pattern to V2 Middleware pattern
- Removed all Axum/Tower type exposure from public API
- Updated tests to use MiddlewarePipelineV2 and pure elif types
- Maintained all existing configuration options and builder patterns

## Changes Made
- ✅ Removed Tower Layer and Service implementations
- ✅ Implemented V2 Middleware trait with `handle(request, next)` pattern  
- ✅ Used pure elif types (`ElifRequest`, `ElifResponse`) instead of Axum types
- ✅ Updated helper functions from layer-based to middleware-based
- ✅ Updated all tests to use MiddlewarePipelineV2
- ✅ Maintained backward compatibility for configuration

## Test Results
All tests pass:
- `test_error_handler_config` ✅
- `test_error_handler_middleware_creation` ✅ 
- `test_error_handler_with_http_error` ✅
- `test_error_handler_normal_flow` ✅
- `test_error_handler_config_default` ✅
- `test_custom_error_handler` ✅

## Breaking Changes
- Removed `ErrorHandlerLayer`, `ErrorHandlerService` (Tower implementations)
- Removed `error_handler_middleware()` function (Tower-based)
- Removed `error_handler_layer*()` functions
- Added `error_handler()` and `error_handler_with_config()` for V2 pattern

Closes #218

🤖 Generated with [Claude Code](https://claude.ai/code)