### PR TITLE
bump: update version numbers for crate publication

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1521,6 +1521,39 @@ dependencies = [
 [[package]]
 name = "elif-http"
 version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a4a6787c077f3f55a5da6cf052d554898484b192229d04b1a80af5d2c28b3e0"
+dependencies = [
+ "argon2",
+ "axum",
+ "axum-extra",
+ "chrono",
+ "elif-core 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-util",
+ "html-escape",
+ "http-body-util",
+ "hyper 1.6.0",
+ "log",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "service-builder",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-tungstenite 0.23.1",
+ "tower 0.4.13",
+ "tower-http 0.5.2",
+ "tracing",
+ "tracing-subscriber",
+ "tungstenite 0.21.0",
+ "uuid",
+]
+
+[[package]]
+name = "elif-http"
+version = "0.8.0"
 dependencies = [
  "argon2",
  "axum",
@@ -1556,39 +1589,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "elif-http"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a4a6787c077f3f55a5da6cf052d554898484b192229d04b1a80af5d2c28b3e0"
-dependencies = [
- "argon2",
- "axum",
- "axum-extra",
- "chrono",
- "elif-core 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-util",
- "html-escape",
- "http-body-util",
- "hyper 1.6.0",
- "log",
- "once_cell",
- "regex",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "service-builder",
- "thiserror 1.0.69",
- "tokio",
- "tokio-tungstenite 0.23.1",
- "tower 0.4.13",
- "tower-http 0.5.2",
- "tracing",
- "tracing-subscriber",
- "tungstenite 0.21.0",
- "uuid",
-]
-
-[[package]]
 name = "elif-http-derive"
 version = "0.1.0"
 dependencies = [
@@ -1616,7 +1616,7 @@ dependencies = [
  "axum",
  "chrono",
  "elif-core 0.5.0",
- "elif-http 0.7.0",
+ "elif-http 0.8.0",
  "elif-openapi-derive",
  "elif-orm 0.7.0",
  "inventory",
@@ -1732,7 +1732,7 @@ dependencies = [
  "axum",
  "base64 0.22.1",
  "elif-core 0.5.0",
- "elif-http 0.7.0",
+ "elif-http 0.8.0",
  "html-escape",
  "http 1.3.1",
  "log",
@@ -1789,7 +1789,7 @@ dependencies = [
  "axum",
  "chrono",
  "elif-core 0.5.0",
- "elif-http 0.7.0",
+ "elif-http 0.8.0",
  "elif-orm 0.7.0",
  "hyper 1.6.0",
  "rand 0.8.5",
@@ -1818,7 +1818,7 @@ dependencies = [
  "axum",
  "chrono",
  "elif-core 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "elif-http 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "elif-http 0.7.0",
  "elif-orm 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 1.6.0",
  "rand 0.8.5",

--- a/crates/elif-http/Cargo.toml
+++ b/crates/elif-http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elif-http"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 description = "HTTP server core for the elif.rs LLM-friendly web framework"
 license = "MIT"

--- a/crates/elif-openapi/Cargo.toml
+++ b/crates/elif-openapi/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["web-programming", "development-tools"]
 [dependencies]
 # Core elif dependencies
 elif-core = { version = "0.5.0", path = "../core" }
-elif-http = { version = "0.7.0", path = "../elif-http" }
+elif-http = { version = "0.8.0", path = "../elif-http" }
 elif-orm = { version = "0.7.0", path = "../orm" }
 
 # Serialization and JSON processing

--- a/crates/elif-security/Cargo.toml
+++ b/crates/elif-security/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["web-programming", "authentication"]
 [dependencies]
 # Core framework dependencies
 elif-core = { version = "0.5.0", path = "../core" }
-elif-http = { version = "0.7.0", path = "../elif-http" }
+elif-http = { version = "0.8.0", path = "../elif-http" }
 service-builder = "0.3.0"
 
 # HTTP and async

--- a/crates/elif-testing/Cargo.toml
+++ b/crates/elif-testing/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["web-programming", "development-tools::testing"]
 [dependencies]
 # Core framework dependencies
 elif-core = { version = "0.5.0", path = "../core" }
-elif-http = { version = "0.7.0", path = "../elif-http" }
+elif-http = { version = "0.8.0", path = "../elif-http" }
 elif-orm = { version = "0.7.0", path = "../orm" }
 
 # HTTP and async runtime


### PR DESCRIPTION
- Bump elif-http from 0.7.0 to 0.8.0 for derive feature addition
- Update version dependencies in elif-openapi, elif-security, elif-testing
- Prepare for publishing elif-http-derive v0.1.0 and elif-http v0.8.0

🤖 Generated with [Claude Code](https://claude.ai/code)