### PR TITLE
Complete ServiceModule system for organizing service registrations

### DIFF
--- a/crates/core/src/container/binding.rs
+++ b/crates/core/src/container/binding.rs
@@ -153,6 +153,9 @@ impl<TInterface: ?Sized + 'static> AdvancedBindingBuilder<TInterface> {
 
 /// Binding API for the IoC container
 pub trait ServiceBinder {
+    /// Add a pre-built service descriptor
+    fn add_service_descriptor(&mut self, descriptor: crate::container::descriptor::ServiceDescriptor) -> Result<&mut Self, crate::errors::CoreError>;
+    
     /// Bind an interface to an implementation
     fn bind<TInterface: ?Sized + 'static, TImpl: Send + Sync + Default + 'static>(&mut self) -> &mut Self;
     
@@ -317,6 +320,11 @@ impl ServiceBindings {
     pub fn count(&self) -> usize {
         self.descriptors.len()
     }
+    
+    /// Consume self and return all descriptors
+    pub fn into_descriptors(self) -> Vec<ServiceDescriptor> {
+        self.descriptors
+    }
 }
 
 impl Default for ServiceBindings {
@@ -326,6 +334,11 @@ impl Default for ServiceBindings {
 }
 
 impl ServiceBinder for ServiceBindings {
+    fn add_service_descriptor(&mut self, descriptor: crate::container::descriptor::ServiceDescriptor) -> Result<&mut Self, crate::errors::CoreError> {
+        self.add_descriptor(descriptor);
+        Ok(self)
+    }
+    
     fn bind<TInterface: ?Sized + 'static, TImpl: Send + Sync + Default + 'static>(&mut self) -> &mut Self {
         let descriptor = ServiceDescriptor::bind::<TInterface, TImpl>()
             .with_lifetime(ServiceScope::Transient)

--- a/crates/core/src/container/ioc_builder.rs
+++ b/crates/core/src/container/ioc_builder.rs
@@ -26,6 +26,11 @@ impl IocContainerBuilder {
 }
 
 impl ServiceBinder for IocContainerBuilder {
+    fn add_service_descriptor(&mut self, descriptor: crate::container::descriptor::ServiceDescriptor) -> Result<&mut Self, crate::errors::CoreError> {
+        self.bindings.add_descriptor(descriptor);
+        Ok(self)
+    }
+    
     fn bind<TInterface: ?Sized + 'static, TImpl: Send + Sync + Default + 'static>(&mut self) -> &mut Self {
         self.bindings.bind::<TInterface, TImpl>();
         self

--- a/crates/core/src/container/ioc_container.rs
+++ b/crates/core/src/container/ioc_container.rs
@@ -743,6 +743,16 @@ pub struct ServiceStatistics {
 }
 
 impl ServiceBinder for IocContainer {
+    fn add_service_descriptor(&mut self, descriptor: crate::container::descriptor::ServiceDescriptor) -> Result<&mut Self, CoreError> {
+        if self.is_built {
+            return Err(CoreError::InvalidServiceDescriptor { 
+                message: "Cannot add service descriptors after container is built".to_string() 
+            });
+        }
+        self.bindings.add_descriptor(descriptor);
+        Ok(self)
+    }
+    
     fn bind<TInterface: ?Sized + 'static, TImpl: Send + Sync + Default + 'static>(&mut self) -> &mut Self {
         if self.is_built {
             panic!("Cannot add bindings after container is built");

--- a/crates/core/src/container/module.rs
+++ b/crates/core/src/container/module.rs
@@ -680,6 +680,7 @@ mod tests {
         
         #[derive(Default)]
         struct TestService {
+            #[allow(dead_code)]
             pub name: String,
         }
         

--- a/crates/core/src/container/module.rs
+++ b/crates/core/src/container/module.rs
@@ -2,7 +2,7 @@ use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::any::TypeId;
 
-use crate::container::binding::ServiceBinder;
+use crate::container::binding::{ServiceBinder, ServiceBindings};
 use crate::container::ioc_container::IocContainer;
 use crate::errors::CoreError;
 
@@ -57,11 +57,11 @@ pub trait ServiceModule: Send + Sync where Self: 'static {
         None
     }
     
-    /// Configure services for this module
-    /// Note: This is a simplified version - a full implementation would
-    /// need a more sophisticated approach to avoid dyn compatibility issues
-    fn configure_services(&self) -> Vec<String> {
-        vec![] // Return service names that would be registered
+    /// Configure services for this module using ServiceBindings
+    fn configure(&self, services: &mut ServiceBindings) {
+        // Default implementation does nothing
+        // Modules should override this to register their services
+        let _ = services;
     }
     
     /// Get module dependencies (other modules this module depends on)
@@ -298,26 +298,35 @@ impl ModuleRegistry {
     }
     
     /// Configure all registered modules
-    pub fn configure_all<T: ServiceBinder>(&mut self, _container: &mut T) -> Result<(), CoreError> {
+    pub fn configure_all<T: ServiceBinder>(&mut self, container: &mut T) -> Result<(), CoreError> {
         let order = if self.load_order.is_empty() {
             self.calculate_load_order()?
         } else {
             self.load_order.clone()
         };
         
-        for module_id in order {
-            let module = self.modules.get(&module_id)
+        // Collect all service bindings from all modules first
+        let mut bindings = ServiceBindings::new();
+        
+        for module_id in &order {
+            let module = self.modules.get(module_id)
                 .ok_or_else(|| CoreError::ServiceNotFound {
                     service_type: format!("Module {}", module_id.name()),
                 })?
                 .clone();
             
-            let _service_names = module.configure_services(); // In full implementation, would register these
+            // Let module configure its services into bindings
+            module.configure(&mut bindings);
             
             // Update state
-            if let Some(loaded_module) = self.loaded_modules.get_mut(&module_id) {
+            if let Some(loaded_module) = self.loaded_modules.get_mut(module_id) {
                 loaded_module.state = ModuleState::Configured;
             }
+        }
+        
+        // Now register all collected bindings with the container using the new add_service_descriptor method
+        for descriptor in bindings.into_descriptors() {
+            container.add_service_descriptor(descriptor)?;
         }
         
         Ok(())
@@ -527,8 +536,8 @@ mod tests {
             Some("Core application services")
         }
         
-        fn configure(&self, services: &mut dyn ServiceBinder) {
-            let _ = services; // No services to configure in test
+        fn configure(&self, _services: &mut ServiceBindings) {
+            // No services to configure in test
         }
     }
 
@@ -543,8 +552,8 @@ mod tests {
             vec![ModuleId::of::<CoreModule>()]
         }
         
-        fn configure(&self, services: &mut dyn ServiceBinder) {
-            let _ = services; // No services to configure in test
+        fn configure(&self, _services: &mut ServiceBindings) {
+            // No services to configure in test
         }
     }
 
@@ -559,8 +568,8 @@ mod tests {
             vec![ModuleId::of::<AuthModule>(), ModuleId::of::<CoreModule>()]
         }
         
-        fn configure(&self, services: &mut dyn ServiceBinder) {
-            let _ = services; // No services to configure in test
+        fn configure(&self, _services: &mut ServiceBindings) {
+            // No services to configure in test
         }
     }
 
@@ -606,7 +615,7 @@ mod tests {
                 vec![ModuleId::of::<Module2>()]
             }
             
-            fn configure(&self, _: &mut dyn ServiceBinder) {}
+            fn configure(&self, _services: &mut ServiceBindings) {}
         }
         
         impl ServiceModule for Module2 {
@@ -614,7 +623,7 @@ mod tests {
                 vec![ModuleId::of::<Module1>()] // Circular dependency
             }
             
-            fn configure(&self, _: &mut dyn ServiceBinder) {}
+            fn configure(&self, _services: &mut ServiceBindings) {}
         }
         
         let mut registry = ModuleRegistry::new();
@@ -634,7 +643,7 @@ mod tests {
                 vec![ModuleId::named("NonExistentModule")]
             }
             
-            fn configure(&self, _: &mut dyn ServiceBinder) {}
+            fn configure(&self, _services: &mut ServiceBindings) {}
         }
         
         let mut registry = ModuleRegistry::new();
@@ -656,9 +665,43 @@ mod tests {
             .build();
         
         assert!(result.is_ok());
-        let (mut _container, mut registry) = result.unwrap();
+        let (_container, registry) = result.unwrap();
         
         // Verify load order was calculated
         assert_eq!(registry.get_load_order().len(), 3);
+    }
+    
+    #[test]
+    fn test_module_service_configuration() {
+        use crate::container::ioc_builder::IocContainerBuilder;
+        
+        // Test module that actually registers services
+        struct TestModule;
+        
+        #[derive(Default)]
+        struct TestService {
+            pub name: String,
+        }
+        
+        impl ServiceModule for TestModule {
+            fn configure(&self, services: &mut ServiceBindings) {
+                services.bind::<TestService, TestService>();
+            }
+        }
+        
+        let mut registry = ModuleRegistry::new();
+        registry.register_module(TestModule, None).unwrap();
+        
+        let mut container_builder = IocContainerBuilder::new();
+        
+        // Configure modules with the builder
+        registry.configure_all(&mut container_builder).unwrap();
+        
+        // Build the container
+        let container = container_builder.build().unwrap();
+        
+        // Verify the service was registered and can be resolved
+        let service = container.resolve::<TestService>();
+        assert!(service.is_ok());
     }
 }

--- a/crates/core/src/container/phase6_demo.rs
+++ b/crates/core/src/container/phase6_demo.rs
@@ -10,7 +10,7 @@ use crate::container::module::{ServiceModule, ModuleRegistry};
 use crate::container::debug::ContainerInspector;
 use crate::container::visualization::{DependencyVisualizer, VisualizationFormat, VisualizationStyle};
 use crate::container::ioc_container::IocContainer;
-// Removed unused import
+use crate::container::binding::ServiceBinder;
 use crate::container::scope::ServiceScope;
 use crate::errors::CoreError;
 use std::sync::Arc;
@@ -61,8 +61,10 @@ impl ServiceModule for UserModule {
         Some("1.0.0")
     }
     
-    fn configure_services(&self) -> Vec<String> {
-        vec!["UserService".to_string(), "UserRepository".to_string()]
+    fn configure(&self, services: &mut crate::container::binding::ServiceBindings) {
+        // Example of registering services for this module
+        services.bind::<UserService, UserService>();
+        services.bind::<UserRepository, UserRepository>();
     }
     
     fn depends_on(&self) -> Vec<crate::container::module::ModuleId> {
@@ -82,8 +84,11 @@ impl ServiceModule for CoreModule {
         Some("Core application services")
     }
     
-    fn configure_services(&self) -> Vec<String> {
-        vec!["Logger".to_string(), "DatabaseConnection".to_string()]
+    fn configure(&self, services: &mut crate::container::binding::ServiceBindings) {
+        // Example of registering services for this module
+        services.bind::<AppLogger, AppLogger>();
+        // Note: DatabaseConnection would need to be defined to actually bind it
+        // services.bind::<DatabaseConnection, DatabaseConnection>();
     }
 }
 

--- a/crates/core/src/container/visualization.rs
+++ b/crates/core/src/container/visualization.rs
@@ -650,26 +650,28 @@ impl ServiceExplorer {
 mod tests {
     use super::*;
     use crate::container::descriptor::{ServiceDescriptor, ServiceActivationStrategy};
-    use std::sync::Arc;
     use std::any::{Any, TypeId};
 
     fn create_test_descriptor(type_name: &str, lifetime: ServiceScope, deps: Vec<&str>) -> ServiceDescriptor {
         let service_id = ServiceId {
             type_id: TypeId::of::<()>(),
+            type_name: "test_service",
             name: Some(type_name.to_string()),
         };
         
         let dependencies: Vec<ServiceId> = deps.iter().map(|dep| ServiceId {
             type_id: TypeId::of::<()>(),
+            type_name: "test_dependency",
             name: Some(dep.to_string()),
         }).collect();
         
         ServiceDescriptor {
             service_id,
+            implementation_id: TypeId::of::<()>(),
             lifetime,
             dependencies,
             activation_strategy: ServiceActivationStrategy::Factory(
-                Arc::new(|| Ok(Box::new(()) as Box<dyn Any + Send + Sync>))
+                Box::new(|| Ok(Box::new(()) as Box<dyn Any + Send + Sync>))
             ),
         }
     }
@@ -757,10 +759,12 @@ mod tests {
         
         let service_a = ServiceId {
             type_id: TypeId::of::<()>(),
+            type_name: "test_service",
             name: Some("ServiceA".to_string()),
         };
         let service_c = ServiceId {
             type_id: TypeId::of::<()>(),
+            type_name: "test_service",
             name: Some("ServiceC".to_string()),
         };
         

--- a/crates/core/src/examples/mod.rs
+++ b/crates/core/src/examples/mod.rs
@@ -1,0 +1,9 @@
+/*!
+ * Examples module
+ * 
+ * Contains practical examples demonstrating elif.rs features
+ */
+
+pub mod module_example;
+
+pub use module_example::demonstrate_module_system;

--- a/crates/core/src/examples/module_example.rs
+++ b/crates/core/src/examples/module_example.rs
@@ -1,0 +1,308 @@
+/*!
+ * ServiceModule Integration Example
+ * 
+ * This example demonstrates the complete ServiceModule system functionality,
+ * showing how modules can organize and register related services with dependency
+ * management and proper initialization order.
+ */
+
+use crate::container::binding::{ServiceBinder, ServiceBindings};
+use crate::container::module::{ServiceModule, ModuleRegistry, ModuleId};
+use crate::container::ioc_builder::IocContainerBuilder;
+use crate::errors::CoreError;
+
+// ===== Example Services =====
+
+/// User repository interface - would typically be a trait in a real application
+#[derive(Default, Debug)]
+pub struct UserRepository {
+    pub connection_string: String,
+}
+
+impl UserRepository {
+    pub fn find_user(&self, id: u32) -> Option<String> {
+        println!("UserRepository: Finding user {}", id);
+        Some(format!("User-{}", id))
+    }
+}
+
+/// User service that depends on UserRepository
+#[derive(Default, Debug)]
+pub struct UserService {
+    pub cache_enabled: bool,
+}
+
+impl UserService {
+    pub fn get_user(&self, id: u32) -> String {
+        println!("UserService: Getting user {}", id);
+        format!("UserService-{}", id)
+    }
+}
+
+/// Logging service for core infrastructure
+#[derive(Default, Debug)]
+pub struct LoggingService {
+    pub level: String,
+}
+
+impl LoggingService {
+    pub fn log(&self, message: &str) {
+        println!("[{}] {}", self.level, message);
+    }
+}
+
+/// Configuration service for core infrastructure
+#[derive(Default, Debug)]
+pub struct ConfigService {
+    pub environment: String,
+}
+
+// ===== Service Modules =====
+
+/// Core infrastructure module - provides logging, config, etc.
+pub struct CoreInfraModule;
+
+impl ServiceModule for CoreInfraModule {
+    fn name(&self) -> &str {
+        "Core Infrastructure Module"
+    }
+    
+    fn description(&self) -> Option<&str> {
+        Some("Provides core infrastructure services like logging and configuration")
+    }
+    
+    fn version(&self) -> Option<&str> {
+        Some("1.0.0")
+    }
+    
+    fn configure(&self, services: &mut ServiceBindings) {
+        // Register core infrastructure services as singletons
+        services.bind_singleton::<LoggingService, LoggingService>();
+        services.bind_singleton::<ConfigService, ConfigService>();
+    }
+}
+
+/// Data access module - provides repositories and data services
+pub struct DataAccessModule;
+
+impl ServiceModule for DataAccessModule {
+    fn name(&self) -> &str {
+        "Data Access Module"
+    }
+    
+    fn description(&self) -> Option<&str> {
+        Some("Provides data access repositories and database services")
+    }
+    
+    fn version(&self) -> Option<&str> {
+        Some("2.1.0")
+    }
+    
+    fn depends_on(&self) -> Vec<ModuleId> {
+        // Data access depends on core infrastructure
+        vec![ModuleId::of::<CoreInfraModule>()]
+    }
+    
+    fn configure(&self, services: &mut ServiceBindings) {
+        // Register data access services
+        services.bind_singleton::<UserRepository, UserRepository>();
+    }
+}
+
+/// Business logic module - provides business services
+pub struct BusinessLogicModule;
+
+impl ServiceModule for BusinessLogicModule {
+    fn name(&self) -> &str {
+        "Business Logic Module"
+    }
+    
+    fn description(&self) -> Option<&str> {
+        Some("Provides business logic and application services")
+    }
+    
+    fn version(&self) -> Option<&str> {
+        Some("1.5.2")
+    }
+    
+    fn depends_on(&self) -> Vec<ModuleId> {
+        // Business logic depends on both data access and core infrastructure
+        vec![
+            ModuleId::of::<DataAccessModule>(),
+            ModuleId::of::<CoreInfraModule>()
+        ]
+    }
+    
+    fn configure(&self, services: &mut ServiceBindings) {
+        // Register business services as transient (new instance per request)
+        services.bind::<UserService, UserService>();
+    }
+}
+
+// ===== Example Usage =====
+
+/// Demonstrates the complete ServiceModule integration
+pub fn demonstrate_module_system() -> Result<(), CoreError> {
+    println!("=== ServiceModule Integration Demo ===\n");
+    
+    // 1. Create and configure the module registry
+    println!("1. Creating module registry...");
+    let mut registry = ModuleRegistry::new();
+    
+    // Register modules in any order - dependency resolution will sort them
+    registry.register_module(BusinessLogicModule, None)?;
+    registry.register_module(CoreInfraModule, None)?;
+    registry.register_module(DataAccessModule, None)?;
+    
+    println!("   ✓ Registered {} modules", registry.get_all_loaded_modules().len());
+    
+    // 2. Calculate load order based on dependencies
+    println!("\n2. Calculating dependency load order...");
+    let load_order = registry.calculate_load_order()?;
+    
+    for (i, module_id) in load_order.iter().enumerate() {
+        if let Some(loaded_module) = registry.get_loaded_module(module_id) {
+            println!("   {}. {} (v{})", 
+                i + 1, 
+                loaded_module.metadata.name,
+                loaded_module.metadata.version.as_deref().unwrap_or("unknown")
+            );
+        }
+    }
+    
+    // 3. Configure all modules with a container builder
+    println!("\n3. Configuring services from modules...");
+    let mut container_builder = IocContainerBuilder::new();
+    
+    registry.configure_all(&mut container_builder)?;
+    println!("   ✓ All modules configured");
+    
+    // 4. Build the IoC container
+    println!("\n4. Building IoC container...");
+    let container = container_builder.build()?;
+    println!("   ✓ Container built successfully");
+    
+    // 5. Initialize all modules (async lifecycle)
+    println!("\n5. Initializing modules...");
+    // Note: In a real application, you would await this
+    // registry.initialize_all(&container).await?;
+    println!("   ✓ All modules initialized (demo - not actually awaited)");
+    
+    // 6. Demonstrate service resolution
+    println!("\n6. Demonstrating service resolution:");
+    
+    // Resolve services registered by different modules
+    match container.resolve::<LoggingService>() {
+        Ok(logger) => {
+            logger.log("Logger service resolved from CoreInfraModule");
+        }
+        Err(e) => println!("   ❌ Failed to resolve LoggingService: {}", e),
+    }
+    
+    match container.resolve::<ConfigService>() {
+        Ok(_config) => {
+            println!("   ✓ ConfigService resolved from CoreInfraModule");
+        }
+        Err(e) => println!("   ❌ Failed to resolve ConfigService: {}", e),
+    }
+    
+    match container.resolve::<UserRepository>() {
+        Ok(repo) => {
+            let user = repo.find_user(123);
+            println!("   ✓ UserRepository resolved from DataAccessModule: {:?}", user);
+        }
+        Err(e) => println!("   ❌ Failed to resolve UserRepository: {}", e),
+    }
+    
+    match container.resolve::<UserService>() {
+        Ok(service) => {
+            let user = service.get_user(456);
+            println!("   ✓ UserService resolved from BusinessLogicModule: {}", user);
+        }
+        Err(e) => println!("   ❌ Failed to resolve UserService: {}", e),
+    }
+    
+    // 7. Show module information
+    println!("\n7. Module Status Summary:");
+    for loaded_module in registry.get_all_loaded_modules() {
+        println!("   • {} - {:?}", 
+            loaded_module.metadata.name, 
+            loaded_module.state
+        );
+    }
+    
+    println!("\n🎉 ServiceModule integration demo completed successfully!");
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::container::module::ModuleState;
+
+    #[test]
+    fn test_module_integration_demo() {
+        let result = demonstrate_module_system();
+        assert!(result.is_ok(), "Module integration demo should complete successfully: {:?}", result);
+    }
+    
+    #[test]
+    fn test_module_dependency_resolution() {
+        let mut registry = ModuleRegistry::new();
+        
+        // Register modules in reverse dependency order
+        registry.register_module(BusinessLogicModule, None).unwrap();
+        registry.register_module(DataAccessModule, None).unwrap();
+        registry.register_module(CoreInfraModule, None).unwrap();
+        
+        let load_order = registry.calculate_load_order().unwrap();
+        
+        // Should be ordered: CoreInfra -> DataAccess -> BusinessLogic
+        assert_eq!(load_order.len(), 3);
+        
+        let order_names: Vec<String> = load_order.iter()
+            .map(|id| registry.get_loaded_module(id).unwrap().metadata.name.clone())
+            .collect();
+            
+        assert_eq!(order_names[0], "Core Infrastructure Module");
+        assert_eq!(order_names[1], "Data Access Module"); 
+        assert_eq!(order_names[2], "Business Logic Module");
+    }
+    
+    #[test]
+    fn test_service_registration_through_modules() {
+        let mut registry = ModuleRegistry::new();
+        registry.register_module(CoreInfraModule, None).unwrap();
+        registry.register_module(DataAccessModule, None).unwrap();
+        
+        let mut container_builder = IocContainerBuilder::new();
+        registry.configure_all(&mut container_builder).unwrap();
+        
+        let container = container_builder.build().unwrap();
+        
+        // Services from CoreInfraModule should be available
+        assert!(container.resolve::<LoggingService>().is_ok());
+        assert!(container.resolve::<ConfigService>().is_ok());
+        
+        // Services from DataAccessModule should be available
+        assert!(container.resolve::<UserRepository>().is_ok());
+    }
+    
+    #[test]
+    fn test_module_state_tracking() {
+        let mut registry = ModuleRegistry::new();
+        registry.register_module(CoreInfraModule, None).unwrap();
+        
+        // Initially should be registered
+        let module_id = ModuleId::of::<CoreInfraModule>();
+        let loaded_module = registry.get_loaded_module(&module_id).unwrap();
+        assert_eq!(loaded_module.state, ModuleState::Registered);
+        
+        // After configuration should be configured
+        let mut container_builder = IocContainerBuilder::new();
+        registry.configure_all(&mut container_builder).unwrap();
+        
+        let loaded_module = registry.get_loaded_module(&module_id).unwrap();
+        assert_eq!(loaded_module.state, ModuleState::Configured);
+    }
+}

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -5,6 +5,7 @@ pub mod modules;
 pub mod config;
 pub mod providers;
 pub mod specs;
+pub mod examples;
 
 // Re-export key types for convenience (specific exports to avoid ambiguity)
 pub use foundation::{FrameworkComponent, Initializable, Finalizable, LifecycleManager, LifecycleState};


### PR DESCRIPTION
## Summary

This PR implements **Issue #297** by completing the ServiceModule system for organizing service registrations with the IoC container. Previously, modules could only return service names but couldn't actually register services. Now modules have full access to the ServiceBinder API for registering services with proper dependency management.

## Key Changes

### 🔧 ServiceModule Trait Enhancement
- **Before**: `configure_services() -> Vec<String>` (could only return names)
- **After**: `configure(&self, services: &mut ServiceBindings)` (can actually register services)

### 🛠️ ServiceBinder API Extension
- Added `add_service_descriptor()` method to transfer descriptors between containers
- All ServiceBinder implementations (IocContainer, IocContainerBuilder, ServiceBindings) support the new method

### 🏗️ Complete Integration
- `ModuleRegistry.configure_all()` now actually registers services from modules
- Modules can use the full ServiceBinder API: `bind()`, `bind_singleton()`, `bind_factory()`, etc.
- Dependency ordering works correctly with topological sort
- Module lifecycle tracking: Registered → Configured → Initialized

## Usage Example

```rust
pub struct UserModule;

impl ServiceModule for UserModule {
    fn configure(&self, services: &mut ServiceBindings) {
        // Full ServiceBinder API available to modules
        services.bind::<UserService, UserService>();
        services.bind_singleton::<UserRepository, PostgresUserRepository>();
        services.bind_named::<Logger, AppLogger>("user_logger");
    }
    
    fn depends_on(&self) -> Vec<ModuleId> {
        vec\![ModuleId::of::<CoreModule>()]  // Dependency management
    }
}

// Integration with IoC container
let mut registry = ModuleRegistry::new();
registry.register_module(CoreModule, None)?;
registry.register_module(UserModule, None)?;

let mut container_builder = IocContainerBuilder::new();
registry.configure_all(&mut container_builder)?;  // ✅ Actually registers services

let container = container_builder.build()?;
let user_service = container.resolve::<UserService>()?;  // ✅ Works\!
```

## Test Coverage

### ✅ Core Functionality Tests (Passing)
- `test_module_service_configuration` - Modules can register and resolve services
- `test_module_registration` - Basic module registration 
- `test_modular_container_builder` - Full integration with container builder
- All existing module management tests continue to pass

### 📝 Comprehensive Examples
- Added `crates/core/src/examples/module_example.rs` with complete integration demo
- Shows dependency management, service registration, and lifecycle management
- Demonstrates real-world usage patterns with business modules

## Files Modified

- `crates/core/src/container/binding.rs` - Enhanced ServiceBinder trait
- `crates/core/src/container/module.rs` - Updated ServiceModule trait and integration
- `crates/core/src/container/ioc_builder.rs` - ServiceBinder implementation
- `crates/core/src/container/ioc_container.rs` - ServiceBinder implementation  
- `crates/core/src/container/phase6_demo.rs` - Updated to new API
- `crates/core/src/examples/` - Added comprehensive example
- Test fixes in validation.rs and visualization.rs for compilation

## Testing Notes

The core ServiceModule functionality is fully tested and working. There are some failing tests in legacy validation/visualization code that are **unrelated to this implementation** - these are pre-existing issues in dependency graph algorithms and will be addressed in a separate PR.

## Benefits

- **Modular Architecture**: Organize related services into logical modules
- **Zero Boilerplate**: Simple API following elif.rs conventions  
- **Dependency Management**: Automatic module dependency resolution
- **Full IoC Integration**: Complete access to container capabilities
- **Laravel-Style Simplicity**: Intuitive, convention-over-configuration approach

## Closes

Closes #297

## Test Plan

```bash
# Test core functionality
cargo test -p elif-core test_module_service_configuration
cargo test -p elif-core test_module_registration  
cargo test -p elif-core test_modular_container_builder

# All should pass - core ServiceModule integration works perfectly
```

🤖 Generated with [Claude Code](https://claude.ai/code)