### PR TITLE
Fix controller registration in CLI templates

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1298,11 +1298,11 @@ use super::users_service::UsersService;
 use super::dto::{{CreateUserDto, UpdateUserDto}};
 
 #[derive(Default)]
-#[controller("/api/users")]
 pub struct UsersController {{
     users_service: Option<UsersService>,
 }}
 
+#[controller("/api/users")]
 impl UsersController {{
     #[get("/")]
     pub async fn index(&self) -> HttpResult<ElifResponse> {{
@@ -1435,9 +1435,9 @@ pub struct UpdateUserDto {
 use serde_json::json;
 
 #[derive(Default)]
-#[controller("/api")]
 pub struct HealthController;
 
+#[controller("/api")]
 impl HealthController {{
     #[get("/health")]
     pub async fn health(&self) -> HttpResult<ElifResponse> {{

--- a/crates/elif/src/prelude.rs
+++ b/crates/elif/src/prelude.rs
@@ -16,6 +16,11 @@ pub use elif_http::{ElifRequest, ElifResponse};
 // Common traits - using correct exports
 pub use elif_http::GenericHandler as Handler;
 pub use elif_http::{IntoElifResponse, Middleware};
+
+// Controller types needed for macros
+pub use elif_http::controller::{ElifController, ControllerRoute, RouteParam};
+pub use elif_http::routing::HttpMethod;
+pub use elif_http::routing::params::ParamType;
 pub use elif_orm::Model;
 
 // Core types


### PR DESCRIPTION
- Move #[controller] attribute from struct to impl block
- Controllers were registering with 0 routes when attribute was on struct
- Now routes are properly collected and registered

The issue was that the controller macro generates an empty routes() method when applied to structs, but collects actual routes when applied to impl blocks. CLI was incorrectly placing the attribute on structs.

Fixes route registration for generated projects