### PR TITLE
Version bump: 0.2.11, 0.8.7, 0.12.10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1663,7 +1663,7 @@ dependencies = [
 
 [[package]]
 name = "elif-http-derive"
-version = "0.2.10"
+version = "0.2.11"
 dependencies = [
  "async-trait",
  "ctor",
@@ -1945,7 +1945,7 @@ dependencies = [
 
 [[package]]
 name = "elif-web"
-version = "0.8.6"
+version = "0.8.7"
 dependencies = [
  "async-trait",
  "elif-auth",
@@ -1964,7 +1964,7 @@ dependencies = [
 
 [[package]]
 name = "elifrs"
-version = "0.12.9"
+version = "0.12.10"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elifrs"
-version = "0.12.9"
+version = "0.12.10"
 edition = "2021"
 description = "elif.rs CLI - Convention over configuration web framework tooling with zero-boilerplate project generation"
 license = "MIT"
@@ -17,7 +17,7 @@ name = "elifrs"
 path = "src/main.rs"
 
 [dependencies]
-elif-web = { version = "0.8.6", path = "../elif-web" }
+elif-web = { version = "0.8.7", path = "../elif-web" }
 elif-core = { version = "0.7.1", path = "../core" }
 elif-codegen = { version = "0.4.0", path = "../codegen" }
 elif-introspect = { version = "0.3.0", path = "../introspect" }

--- a/crates/elif-http-derive/Cargo.toml
+++ b/crates/elif-http-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elif-http-derive"
-version = "0.2.10"
+version = "0.2.11"
 edition = "2021"
 description = "Derive macros for elif-http declarative routing and controller system"
 license = "MIT"

--- a/crates/elif-http/Cargo.toml
+++ b/crates/elif-http/Cargo.toml
@@ -15,7 +15,7 @@ categories = ["web-programming", "network-programming"]
 # Framework dependencies
 elif-core = { version = "0.7.1", path = "../core" }
 elif-auth = { version = "0.4.0", path = "../elif-auth", optional = true }
-elif-http-derive = { version = "0.2.9", path = "../elif-http-derive", optional = true }
+elif-http-derive = { version = "0.2.11", path = "../elif-http-derive", optional = true }
 
 # HTTP server
 axum = { workspace = true, features = ["ws"] }

--- a/crates/elif-web/Cargo.toml
+++ b/crates/elif-web/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elif-web"
-version = "0.8.6"
+version = "0.8.7"
 edition = "2021"
 description = "Modern Rust web framework designed for exceptional developer experience"
 license = "MIT"
@@ -19,7 +19,7 @@ elif-orm = { version = "0.7.1", path = "../orm" }
 elif-auth = { version = "0.4.1", path = "../elif-auth" }
 elif-cache = { version = "0.3.0", path = "../elif-cache" }
 elif-macros = { version = "0.2.0", path = "../elif-macros" }
-elif-http-derive = { version = "0.2.9", path = "../elif-http-derive" }
+elif-http-derive = { version = "0.2.11", path = "../elif-http-derive" }
 
 # These are no longer needed since macros are in separate crate
 # proc-macro2 = "1.0"


### PR DESCRIPTION
- elif-http-derive: 0.2.10 → 0.2.11 (code cleanup, dead code removal)
- elif-web: 0.8.6 → 0.8.7 (directory rename for consistency)
- elifrs: 0.12.9 → 0.12.10 (dev command improvements)
- Update dependent crate version references

🤖 Generated with [Claude Code](https://claude.ai/code)